### PR TITLE
feat: initial toJSON for WAVChunk

### DIFF
--- a/include/WAVChunk.h
+++ b/include/WAVChunk.h
@@ -6,6 +6,7 @@
 
 /*Custom Includes*/
 #include "BaseChunk.h"
+#include "ChunkToJSONConverter.h"
 
 /**
  * @brief WAV header structure that is 32 bytes large
@@ -40,7 +41,8 @@ typedef struct WAVHeader
  * @brief Class that encapsulated time domain data with a WAV header
  */
 class WAVChunk :
-    public BaseChunk
+    public BaseChunk,
+    public ChunkToJSONConverter
 {
 
 public:
@@ -116,6 +118,11 @@ public:
      * @return Reference to the class with which we want to compare
      */
     bool IsEqual(WAVChunk& wavChunk);
+
+    /**
+    * @brief Returns the JSON equivalent of this classes representation
+    */
+    std::shared_ptr<nlohmann::json> ToJSON() override;
 
 private:
     /**

--- a/include/WAVChunk.h
+++ b/include/WAVChunk.h
@@ -35,6 +35,28 @@ typedef struct WAVHeader
         return std::memcmp(this, &sWAVHeader, sizeof(WAVHeader)) == 0;
     }
 
+    std::shared_ptr<nlohmann::json> ToJSON() {
+        auto JSONDocument = nlohmann::json();
+        for (size_t RIFFIndex = 0; RIFFIndex < 4; RIFFIndex++)
+            JSONDocument["RIFF"][RIFFIndex] = RIFF[RIFFIndex];
+        JSONDocument["ChunkSize"] = ChunkSize;
+        for (size_t WAVEIndex = 0; WAVEIndex < 4; WAVEIndex++)
+            JSONDocument["WAVE"][WAVEIndex] = WAVE[WAVEIndex];
+        for (size_t fmtIndex = 0; fmtIndex < 4; fmtIndex++)
+            JSONDocument["fmt"][fmtIndex] = fmt[fmtIndex];
+        JSONDocument["Subchunk1Size"] = Subchunk1Size;
+        JSONDocument["AudioFormat"] = AudioFormat;
+        JSONDocument["NumOfChan"] = NumOfChan;
+        JSONDocument["SamplesPerSec"] = SamplesPerSec;
+        JSONDocument["bytesPerSec"] = bytesPerSec;
+        JSONDocument["blockAlign"] = blockAlign;
+        JSONDocument["bitsPerSample"] = bitsPerSample;
+        for (size_t Subchunk2IDIndex = 0; Subchunk2IDIndex < 4; Subchunk2IDIndex++)
+            JSONDocument["Subchunk2ID"][Subchunk2IDIndex] = Subchunk2ID[Subchunk2IDIndex];
+        JSONDocument["Subchunk2Size"] = Subchunk2Size;
+
+        return std::make_shared<nlohmann::json>(JSONDocument);
+    }
 } WAVHeader;
 
 /**

--- a/include_tests/WAVChunkTests.h
+++ b/include_tests/WAVChunkTests.h
@@ -71,7 +71,33 @@ TEST_CASE("WAVChunk Test") {
     auto strChunkName = ChunkTypesNamingUtility::toString(ChunkType::WAVChunk);
     JSONDocument[strChunkName]["SourceIndentifierSize"] = std::to_string(0);
     JSONDocument[strChunkName]["SourceIndentifier"] = std::vector<uint8_t>();
-    JSONDocument[strChunkName]["WAVHeader"] = "ChunkSize: 0\nSubchunk1Size: 16\nAudioFormat: 1\nNumOfChan: 2\nSamplesPerSec: 0\nBytesPerSec: 0\nBlockAlign: 0\nBitsPerSample: 0\nSubchunk2Size: 8\n";
+
+    JSONDocument[strChunkName]["WAVHeader"]["RIFF"][0] = 82;
+    JSONDocument[strChunkName]["WAVHeader"]["RIFF"][1] = 73;
+    JSONDocument[strChunkName]["WAVHeader"]["RIFF"][2] = 70;
+    JSONDocument[strChunkName]["WAVHeader"]["RIFF"][3] = 70;
+    JSONDocument[strChunkName]["WAVHeader"]["ChunkSize"] = 0;
+    JSONDocument[strChunkName]["WAVHeader"]["WAVE"][0] = 87;
+    JSONDocument[strChunkName]["WAVHeader"]["WAVE"][1] = 65;
+    JSONDocument[strChunkName]["WAVHeader"]["WAVE"][2] = 86;
+    JSONDocument[strChunkName]["WAVHeader"]["WAVE"][3] = 69;
+    JSONDocument[strChunkName]["WAVHeader"]["fmt"][0] = 102;
+    JSONDocument[strChunkName]["WAVHeader"]["fmt"][1] = 109;
+    JSONDocument[strChunkName]["WAVHeader"]["fmt"][2] = 116;
+    JSONDocument[strChunkName]["WAVHeader"]["fmt"][3] = 32;
+    JSONDocument[strChunkName]["WAVHeader"]["Subchunk1Size"] = 16;
+    JSONDocument[strChunkName]["WAVHeader"]["AudioFormat"] = 1;
+    JSONDocument[strChunkName]["WAVHeader"]["NumOfChan"] = 2;
+    JSONDocument[strChunkName]["WAVHeader"]["SamplesPerSec"] = 0;
+    JSONDocument[strChunkName]["WAVHeader"]["bytesPerSec"] = 0;
+    JSONDocument[strChunkName]["WAVHeader"]["blockAlign"] = 0;
+    JSONDocument[strChunkName]["WAVHeader"]["bitsPerSample"] = 0;
+    JSONDocument[strChunkName]["WAVHeader"]["Subchunk2Size"] = 8;
+    JSONDocument[strChunkName]["WAVHeader"]["Subchunk2ID"][0] = 100;
+    JSONDocument[strChunkName]["WAVHeader"]["Subchunk2ID"][1] = 97;
+    JSONDocument[strChunkName]["WAVHeader"]["Subchunk2ID"][2] = 116;
+    JSONDocument[strChunkName]["WAVHeader"]["Subchunk2ID"][3] = 97;
+
     JSONDocument[strChunkName]["ChunkSize"] = "70";
     JSONDocument[strChunkName]["TimeStamp"] = "0";
     JSONDocument[strChunkName]["VI16Data"] = "10101010";

--- a/include_tests/WAVChunkTests.h
+++ b/include_tests/WAVChunkTests.h
@@ -66,6 +66,19 @@ TEST_CASE("WAVChunk Test") {
         // Checking if setting data works correctly
         CHECK(WAVChunkTestClass.m_sWAVHeader == sWAVHeaderDesrialised);
     }
+
+    auto JSONDocument = nlohmann::json();
+    auto strChunkName = ChunkTypesNamingUtility::toString(ChunkType::WAVChunk);
+    JSONDocument[strChunkName]["SourceIndentifierSize"] = std::to_string(0);
+    JSONDocument[strChunkName]["SourceIndentifier"] = std::vector<uint8_t>();
+    JSONDocument[strChunkName]["WAVHeader"] = "ChunkSize: 0\nSubchunk1Size: 16\nAudioFormat: 1\nNumOfChan: 2\nSamplesPerSec: 0\nBytesPerSec: 0\nBlockAlign: 0\nBitsPerSample: 0\nSubchunk2Size: 8\n";
+    JSONDocument[strChunkName]["ChunkSize"] = "70";
+    JSONDocument[strChunkName]["TimeStamp"] = "0";
+    JSONDocument[strChunkName]["VI16Data"] = "10101010";
+
+    SUBCASE("Checking ToJSON Converter") {
+        CHECK(*(WAVChunkTestClass.ToJSON()) == JSONDocument);
+    }
 }
 
 #endif

--- a/source/WAVChunk.cpp
+++ b/source/WAVChunk.cpp
@@ -189,7 +189,7 @@ std::shared_ptr<nlohmann::json> WAVChunk::ToJSON()
 	JSONDocument[strChunkName]["SourceIndentifier"] = m_vu8SourceIdentifier;
 
 	// Adding in WAVChunk fields
-	JSONDocument[strChunkName]["WAVHeader"] = GetHeaderString(); // not sure if we want to nest JSON representation here rather?
+	JSONDocument[strChunkName]["WAVHeader"] = *m_sWAVHeader.ToJSON().get();
 	JSONDocument[strChunkName]["ChunkSize"] = std::to_string(GetSize());
 	JSONDocument[strChunkName]["TimeStamp"] = std::to_string(m_i64TimeStamp);
 

--- a/source/WAVChunk.cpp
+++ b/source/WAVChunk.cpp
@@ -178,3 +178,27 @@ bool WAVChunk::IsEqual(WAVChunk &wavChunk)
 
 	return bIsEqual;
 }
+
+std::shared_ptr<nlohmann::json> WAVChunk::ToJSON()
+{
+	auto JSONDocument = nlohmann::json();
+	auto strChunkName = ChunkTypesNamingUtility::toString(GetChunkType());
+
+	// Adding in Basechunk fields
+	JSONDocument[strChunkName]["SourceIndentifierSize"] = std::to_string(m_u16SourceIndentifierSize);
+	JSONDocument[strChunkName]["SourceIndentifier"] = m_vu8SourceIdentifier;
+
+	// Adding in WAVChunk fields
+	JSONDocument[strChunkName]["WAVHeader"] = GetHeaderString(); // not sure if we want to nest JSON representation here rather?
+	JSONDocument[strChunkName]["ChunkSize"] = std::to_string(GetSize());
+	JSONDocument[strChunkName]["TimeStamp"] = std::to_string(m_i64TimeStamp);
+
+	std::stringstream stream;
+
+	for (size_t i = 0; i < m_vi16Data.size(); ++i) {
+		stream << std::to_string(m_vi16Data[i]);
+	}
+	JSONDocument[strChunkName]["VI16Data"] = stream.str();
+
+	return std::make_shared<nlohmann::json>(JSONDocument);
+}

--- a/source/WAVChunk.cpp
+++ b/source/WAVChunk.cpp
@@ -195,9 +195,9 @@ std::shared_ptr<nlohmann::json> WAVChunk::ToJSON()
 
 	std::stringstream stream;
 
-	for (size_t i = 0; i < m_vi16Data.size(); ++i) {
-		stream << std::to_string(m_vi16Data[i]);
-	}
+	for (size_t vi16DatumIndex = 0; vi16DatumIndex < m_vi16Data.size(); ++vi16DatumIndex)
+		stream << std::to_string(m_vi16Data[vi16DatumIndex]);
+
 	JSONDocument[strChunkName]["VI16Data"] = stream.str();
 
 	return std::make_shared<nlohmann::json>(JSONDocument);


### PR DESCRIPTION
Currently leaves you with something looking like this:
```json
{
    "WAVChunk": {
        "ChunkSize": "70",
        "SourceIndentifier": [],
        "SourceIndentifierSize": "0",
        "TimeStamp": "0",
        "VI16Data": "10101010",
        "WAVHeader": {
            "AudioFormat": 1,
            "ChunkSize": "0",
            "NumOfChan": 2,
            "RIFF": [
                82,
                73,
                70,
                70
            ],
            "SamplesPerSec": 0,
            "Subchunk1Size": 16,
            "Subchunk2ID": [
                100,
                97,
                116,
                97
            ],
            "Subchunk2Size": 8,
            "WAVE": [
                87,
                65,
                86,
                69
            ],
            "bitsPerSample": 0,
            "blockAlign": 0,
            "bytesPerSec": 0,
            "fmt": [
                102,
                109,
                116,
                32
            ]
        }
    }
}
```
Edited to show `WAVHeader.ToJSON` as well

But I figure we probably want a function that converts `WAVHeader` into a `JSONDocument` too. I can work on that in a bit if so

Closes #26 